### PR TITLE
feat: add -r command line option for raw output

### DIFF
--- a/zsh-ask.zsh
+++ b/zsh-ask.zsh
@@ -92,7 +92,8 @@ function ask() {
     local debug=false
     local satisfied=true
     local input=""
-    while getopts ":hvcdmsiuM:f:t:" opt; do
+    local raw=false
+    while getopts ":hvcdmsiuM:f:t:r" opt; do
         case $opt in
             h)
                 _zsh_ask_show_help
@@ -156,6 +157,9 @@ function ask() {
             s)
                 stream=true
                 ;;
+            r)
+                raw=true
+                ;;
             :)
                 echo "-$OPTARG needs a parameter"
                 return 1
@@ -200,7 +204,9 @@ function ask() {
             echo -E "$history"
         fi
         local data='{"messages":['$history'], "model":"'$model'", "stream":'$stream', "max_tokens":'$tokens'}'
-        echo -n "\033[0;36massistant: \033[0m"
+        if ! $raw; then
+          echo -n "\033[0;36massistant: \033[0m"
+        fi
         local message=""
         local generated_text=""
         if $stream; then
@@ -234,7 +240,9 @@ function ask() {
             fi
             message=$(echo -E $response | jq -r '.choices[].message');  
             generated_text=$(echo -E $message | jq -r '.content')
-            if $makrdown; then
+            if $raw; then
+                echo -E $response
+            elif $makrdown; then
                 echo -E $generated_text | glow
             else
                 echo -E $generated_text

--- a/zsh-ask.zsh
+++ b/zsh-ask.zsh
@@ -56,6 +56,7 @@ function _zsh_ask_show_help() {
   echo "  -s                Enable streaming (Doesn't work with -m yet)."
   echo "  -t <max_tokens>   Set max tokens to <max_tokens>, default sets to 800."
   echo "  -u                Upgrade this plugin."
+  echo "  -r                Print raw output."
   echo "  -d                Print debug information."
 }
 
@@ -93,7 +94,7 @@ function ask() {
     local satisfied=true
     local input=""
     local raw=false
-    while getopts ":hvcdmsiuM:f:t:r" opt; do
+    while getopts ":hvcdmsiurM:f:t:" opt; do
         case $opt in
             h)
                 _zsh_ask_show_help


### PR DESCRIPTION
This PR adds support for a -r command line option. When this option is given, the raw json output will be returned. For example:

```
➜  ~ ask -r who are you
{
  "id": "chatcmpl-73rZdIxdw45iFg5RfRk8c3fYzHBIi",
  "object": "chat.completion",
  "created": 12345692881,
  "model": "gpt-3.5-turbo-0613",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "I am a language model created by OpenAI. I have been trained on a diverse range of data to understand and generate human-like text."
      },
      "finish_reason": "stop"
    }
  ],
  "usage": {
    "prompt_tokens": 47,
    "completion_tokens": 28,
    "total_tokens": 75
  }
}
```